### PR TITLE
Iconライブラリを変更（React Icons → Lucide Icons）

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -9,6 +9,7 @@
     "clsx",
     "devcontainer",
     "gantt",
+    "Kanban",
     "lucide",
     "nextjs",
     "tailwindcss"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "next": "15.0.1",
     "react": "^18",
     "react-dom": "^18",
-    "react-icons": "^5.3.0",
     "tailwind-merge": "^2.5.4",
     "tailwindcss-animate": "^1.0.7"
   },

--- a/src/components/layouts/Header/Header.tsx
+++ b/src/components/layouts/Header/Header.tsx
@@ -1,5 +1,5 @@
+import { House } from "lucide-react";
 import Link from "next/link";
-import { IoHomeOutline } from "react-icons/io5";
 import { Filter } from "./Filter";
 import { Help } from "./Help";
 import { NavProjects } from "./NavProjects";
@@ -14,7 +14,7 @@ export const Header = () => {
     <div className="flex items-center justify-between border-y-2">
       <div className="flex items-center">
         <Link href={"/"}>
-          <IoHomeOutline width={100} height={100} />
+          <House />
         </Link>
         <Link href={"/"}>ダッシュボード</Link>
         <NavProjects />

--- a/src/components/layouts/Header/Help.tsx
+++ b/src/components/layouts/Header/Help.tsx
@@ -1,6 +1,6 @@
-import { IoHelpCircleOutline } from "react-icons/io5";
+import { CircleHelp } from "lucide-react";
 
 export const Help = () => {
   // TODO: ヘルプ機能の実装
-  return <IoHelpCircleOutline />;
+  return <CircleHelp />;
 };

--- a/src/components/layouts/Header/Notification.tsx
+++ b/src/components/layouts/Header/Notification.tsx
@@ -1,6 +1,6 @@
-import { IoNotifications } from "react-icons/io5";
+import { Bell } from "lucide-react";
 
 export const Notification = () => {
   // TODO: お知らせ機能の実装
-  return <IoNotifications />;
+  return <Bell />;
 };

--- a/src/components/layouts/Header/ProfileIcon.tsx
+++ b/src/components/layouts/Header/ProfileIcon.tsx
@@ -5,8 +5,8 @@ import {
   NavigationMenuList,
   NavigationMenuTrigger,
 } from "@radix-ui/react-navigation-menu";
+import { CircleUserRound } from "lucide-react";
 import Link from "next/link";
-import { VscAccount } from "react-icons/vsc";
 
 export const ProfileIcon = () => {
   // TODO: プロフィール機能の実装
@@ -15,7 +15,7 @@ export const ProfileIcon = () => {
       <NavigationMenuList>
         <NavigationMenuItem>
           <NavigationMenuTrigger>
-            <VscAccount />
+            <CircleUserRound />
           </NavigationMenuTrigger>
           <NavigationMenuContent>
             <Link href={"/accounts"}>個人設定</Link>

--- a/src/components/layouts/Header/SearchBox.tsx
+++ b/src/components/layouts/Header/SearchBox.tsx
@@ -1,6 +1,6 @@
-import { BiSearchAlt } from "react-icons/bi";
+import { Search } from "lucide-react";
 
 export const SearchBox = () => {
   // TODO: 検索機能の実装
-  return <BiSearchAlt />;
+  return <Search />;
 };

--- a/src/components/layouts/Header/Watch.tsx
+++ b/src/components/layouts/Header/Watch.tsx
@@ -1,6 +1,6 @@
-import { VscEye } from "react-icons/vsc";
+import { Eye } from "lucide-react";
 
 export const Watch = () => {
   // TODO: ウォッチ機能の実装
-  return <VscEye />;
+  return <Eye />;
 };

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -2,8 +2,8 @@
 
 import { Slot } from "@radix-ui/react-slot";
 import { VariantProps, cva } from "class-variance-authority";
+import { Menu } from "lucide-react";
 import * as React from "react";
-import { RxHamburgerMenu } from "react-icons/rx";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -279,7 +279,7 @@ const SidebarTrigger = React.forwardRef<
       }}
       {...props}
     >
-      <RxHamburgerMenu />
+      <Menu />
       <span className="sr-only">Toggle Sidebar</span>
     </Button>
   );

--- a/src/features/projects/const/projectPages.ts
+++ b/src/features/projects/const/projectPages.ts
@@ -7,9 +7,9 @@ import {
   House,
   List,
   Plus,
+  ScrollText,
   Settings,
   SquareKanban,
-  TableOfContents,
 } from "lucide-react";
 
 export const projectPages = [
@@ -46,7 +46,7 @@ export const projectPages = [
   {
     title: "Wiki",
     url: "/wiki",
-    icon: TableOfContents,
+    icon: ScrollText,
   },
   {
     title: "ファイル",

--- a/src/features/projects/const/projectPages.ts
+++ b/src/features/projects/const/projectPages.ts
@@ -1,66 +1,71 @@
-import { BiSolidHome } from "react-icons/bi";
-import { FaFolder, FaGitAlt, FaPlus } from "react-icons/fa";
-import { FaChartGantt } from "react-icons/fa6";
-import { FcWikipedia } from "react-icons/fc";
-import { IoIosListBox, IoIosSettings } from "react-icons/io";
-import { IoDocumentTextOutline } from "react-icons/io5";
-import { MdOutlineViewKanban } from "react-icons/md";
-import { SiSubversion } from "react-icons/si";
+import {
+  ChartGantt,
+  FileText,
+  Folder,
+  GitCommitHorizontal,
+  GitGraph,
+  House,
+  List,
+  Plus,
+  Settings,
+  SquareKanban,
+  TableOfContents,
+} from "lucide-react";
 
 export const projectPages = [
   {
     title: "ホーム",
     url: "/",
-    icon: BiSolidHome,
+    icon: House,
   },
   {
     title: "課題の追加",
     url: "/add",
-    icon: FaPlus,
+    icon: Plus,
   },
   {
     title: "課題",
     url: "/find",
-    icon: IoIosListBox,
+    icon: List,
   },
   {
     title: "ボード",
     url: "/board",
-    icon: MdOutlineViewKanban,
+    icon: SquareKanban,
   },
   {
     title: "ガントチャート",
     url: "/gantt",
-    icon: FaChartGantt,
+    icon: ChartGantt,
   },
   {
     title: "ドキュメント",
     url: "/document",
-    icon: IoDocumentTextOutline,
+    icon: FileText,
   },
   {
     title: "Wiki",
     url: "/wiki",
-    icon: FcWikipedia,
+    icon: TableOfContents,
   },
   {
     title: "ファイル",
     url: "file",
-    icon: FaFolder,
+    icon: Folder,
   },
   {
     title: "Subversion",
     url: "/subversion",
-    icon: SiSubversion,
+    icon: GitCommitHorizontal,
   },
   {
     title: "Git",
     url: "/git",
-    icon: FaGitAlt,
+    icon: GitGraph,
   },
   {
     title: "プロジェクト設定",
     url: "/settings",
-    icon: IoIosSettings,
+    icon: Settings,
   },
 ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -2537,11 +2537,6 @@ react-dom@^18:
     loose-envify "^1.1.0"
     scheduler "^0.23.2"
 
-react-icons@^5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-5.3.0.tgz#ccad07a30aebd40a89f8cfa7d82e466019203f1c"
-  integrity sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==
-
 react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -2797,16 +2792,7 @@ streamsearch@^1.1.0:
   resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
   integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -2887,14 +2873,7 @@ string.prototype.trimstart@^1.0.8:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
# 概要

<!-- このプルリクエストの概要を記述してください。-->

Iconライブラリを変更（React Icons → Lucide Icons）

## 関連 Issue

<!-- 変更に関連するIssueをリンクしてください。なければこのセクションごと削除してください。 -->

- #26 

## やったこと

<!-- 変更内容を記述してください。 -->

- [build: ➖ react-iconsを廃止](https://github.com/kuairen-227/nextjs-practice/commit/6ddd00c1026ba53ee90af84c8d4193a00d2c33e9)
- [fix: 💄 react-iconsをlucide-reactに置換](https://github.com/kuairen-227/nextjs-practice/commit/1aa832d5c7bb652a2368a038b0d13b4fa00ef6c2)