### PR TITLE
プロジェクト一覧取得APIを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "react": "^18",
     "react-dom": "^18",
     "tailwind-merge": "^2.5.4",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/node": "^22",

--- a/src/components/layouts/Header/NavProjects.tsx
+++ b/src/components/layouts/Header/NavProjects.tsx
@@ -7,12 +7,14 @@ import {
   NavigationMenuTrigger,
   navigationMenuTriggerStyle,
 } from "@/components/ui/navigation-menu";
-import { ProjectList } from "@/feature/projects/api/getProjects";
+import { getProjects } from "@/features/projects/api";
 import Link from "next/link";
 
-export const NavProjects = () => {
-  // TODO: プロジェクト一覧取得機能の実装
-  const projects = ProjectList;
+/**
+ * プロジェクトナビゲーション
+ */
+export const NavProjects = async () => {
+  const projects = await getProjects();
 
   return (
     <NavigationMenu>

--- a/src/features/projects/api/getProjects.ts
+++ b/src/features/projects/api/getProjects.ts
@@ -1,0 +1,9 @@
+import { GetProjects } from "../types";
+
+/**
+ * プロジェクト一覧取得API
+ */
+export const getProjects = async (): Promise<GetProjects> => {
+  const res = await fetch("http://localhost:5020/api/v1/projects");
+  return res.json();
+};

--- a/src/features/projects/api/index.ts
+++ b/src/features/projects/api/index.ts
@@ -1,0 +1,1 @@
+export * from "./getProjects";

--- a/src/features/projects/schema/index.ts
+++ b/src/features/projects/schema/index.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+/**
+ * プロジェクトベーススキーマ
+ */
+export const projectSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string().min(1),
+  description: z.string().optional(),
+});
+
+/**
+ * プロジェクト一覧取得スキーマ
+ */
+export const getProjectsSchema = projectSchema.array().brand<"GetProjects">();

--- a/src/features/projects/types/index.ts
+++ b/src/features/projects/types/index.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+import { type getProjectsSchema } from "../schema";
+
+/**
+ * プロジェクト一覧取得
+ */
+export type GetProjects = z.infer<typeof getProjectsSchema>;

--- a/src/mocks/handlers/__mocks__/projects.ts
+++ b/src/mocks/handlers/__mocks__/projects.ts
@@ -1,29 +1,32 @@
+import { getProjectsSchema } from "@/features/projects/schema";
 import { http, HttpResponse } from "msw";
 
 // TODO: サンプルのため、改めてスキーマ定義のうえで修正する
 export const projectsHandlers = [
   http.get("http://localhost:5020/api/v1/projects", () => {
-    return HttpResponse.json([
-      {
-        id: "4e6b3b92-98eb-440a-b543-d113b78feba0",
-        name: "プロジェクト1",
-        description: "プロジェクト1の説明",
-      },
-      {
-        id: "77b01c7c-13f0-4e79-acdb-6f2d724596bf",
-        name: "プロジェクト2",
-        description: "プロジェクト2の説明",
-      },
-      {
-        id: "0fec3261-c12e-445a-b55f-e12efd59741d",
-        name: "プロジェクト3",
-        description: "プロジェクト3の説明",
-      },
-      {
-        id: "a0dee837-3f64-483b-b3e0-8c3ab3322c54",
-        name: "プロジェクト4",
-        description: "プロジェクト4の説明",
-      },
-    ]);
+    return HttpResponse.json(mockProjects);
   }),
 ];
+
+const mockProjects = getProjectsSchema.parse([
+  {
+    id: "4e6b3b92-98eb-440a-b543-d113b78feba0",
+    name: "プロジェクト1",
+    description: "プロジェクト1の説明",
+  },
+  {
+    id: "77b01c7c-13f0-4e79-acdb-6f2d724596bf",
+    name: "プロジェクト2",
+    description: "プロジェクト2の説明",
+  },
+  {
+    id: "0fec3261-c12e-445a-b55f-e12efd59741d",
+    name: "プロジェクト3",
+    description: "プロジェクト3の説明",
+  },
+  {
+    id: "a0dee837-3f64-483b-b3e0-8c3ab3322c54",
+    name: "プロジェクト4",
+    description: "プロジェクト4の説明",
+  },
+]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2990,16 +2990,7 @@ strict-event-emitter@^0.5.1:
   resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz#1602ece81c51574ca39c6815e09f1a3e8550bd93"
   integrity sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -3080,14 +3071,7 @@ string.prototype.trimstart@^1.0.8:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -3435,7 +3419,7 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -3448,15 +3432,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
@@ -3508,3 +3483,8 @@ yoctocolors-cjs@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz#f4b905a840a37506813a7acaa28febe97767a242"
   integrity sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==
+
+zod@^3.23.8:
+  version "3.23.8"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.23.8.tgz#e37b957b5d52079769fb8097099b592f0ef4067d"
+  integrity sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==


### PR DESCRIPTION
# 概要

プロジェクト一覧取得APIを追加

## 関連 Issue

<!-- 変更に関連するIssueをリンクしてください。なければこのセクションごと削除してください。 -->

- #43 

## やったこと

<!-- 変更内容を記述してください。 -->

- [build: 📦 zodの導入](https://github.com/kuairen-227/nextjs-practice/commit/204ba8afb183edcac1889f3bca0abb42d6351d7c)
- [feat: ✨ プロジェクト一覧取得APIの追加](https://github.com/kuairen-227/nextjs-practice/commit/f68f9dd73622251c360f9515766b4b8e3176272a)
- [fix: ✨ プロジェクトナビゲーションでプロジェクト一覧取得APIを使用](https://github.com/kuairen-227/nextjs-practice/commit/454558d754ba87e1429a1140f2eabd295b8b6970)
- [fix: 🐛 mockデータをparseするよう修正](https://github.com/kuairen-227/nextjs-practice/commit/2ea8bdb3bc6fdc50e3308daa3a0b291d7bf4490f)